### PR TITLE
feat: change fine-grained token

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,21 @@
 
 Rename `wrangler.toml.example` to `wrangler.toml`.
 
+## GitHub Token
+
+Use a [fine-grained token](https://github.com/settings/tokens?type=beta) with the following repository permissions:
+
+| Permission | Access |
+|-----------|--------|
+| Metadata | Read (auto-granted) |
+| Contents | Read |
+| Pull requests | Read |
+| Commit statuses | Read |
+
+> [!NOTE]
+> Organization repositories are excluded by default. You can include them by enabling
+> **"Include organization repositories"** in the Settings page.
+
 ## Development
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ Rename `wrangler.toml.example` to `wrangler.toml`.
 
 Use a [fine-grained token](https://github.com/settings/tokens?type=beta) with the following repository permissions:
 
-| Permission | Access |
-|-----------|--------|
-| Metadata | Read (auto-granted) |
-| Contents | Read |
-| Pull requests | Read |
-| Commit statuses | Read |
+| Permission      | Access              |
+| --------------- | ------------------- |
+| Metadata        | Read (auto-granted) |
+| Contents        | Read                |
+| Pull requests   | Read                |
+| Commit statuses | Read                |
 
 > [!NOTE]
 > Organization repositories are excluded by default. You can include them by enabling

--- a/public/static/css/style.css
+++ b/public/static/css/style.css
@@ -11,6 +11,32 @@
   --color-button-primary-text: #f9fafb;
   --color-button-primary-background: #0a7c70;
   --color-button-primary-hover-background: #0e9a8a;
+  --color-callout-warning-background: #fffbeb;
+  --color-callout-warning-border: #f59e0b;
+  --color-callout-warning-text: #92400e;
+}
+
+.c-callout {
+  padding: 0.75rem 1rem;
+  border-radius: 0.375rem;
+  border-left: 4px solid;
+  margin-bottom: 1rem;
+  font-size: 0.875rem;
+}
+.c-callout p {
+  margin: 0 0 0.5rem;
+}
+.c-callout ul {
+  margin: 0;
+  padding-left: 1.25rem;
+}
+.c-callout li {
+  margin-top: 0.125rem;
+}
+.c-callout--warning {
+  background-color: var(--color-callout-warning-background);
+  border-color: var(--color-callout-warning-border);
+  color: var(--color-callout-warning-text);
 }
 
 html {
@@ -229,6 +255,9 @@ legend {
     --color-button-primary-text: #f9fafb;
     --color-button-primary-background: #1a7469;
     --color-button-primary-hover-background: #208c80;
+    --color-callout-warning-background: #2d2008;
+    --color-callout-warning-border: #d97706;
+    --color-callout-warning-text: #fcd34d;
   }
   .c-main-content__loading-icon {
     color: #eee;

--- a/public/static/js/repository.js
+++ b/public/static/js/repository.js
@@ -9,6 +9,7 @@
       method: "POST",
       headers: {
         "everything-prs-token": ghToken,
+        "everything-prs-include-orgs": settings["include-orgs"] ? "1" : "0",
       },
     });
     const repos = await result.text();

--- a/public/static/js/settings.js
+++ b/public/static/js/settings.js
@@ -1,11 +1,15 @@
 {
   window.addEventListener("DOMContentLoaded", (_) => {
     const ghTokenInput = document.querySelector(".js-gh-token");
+    const includeOrgsInput = document.querySelector(".js-include-orgs");
 
     const localStorageKey = "everything-prs";
     const localStorageValue = localStorage.getItem(localStorageKey) || "{}";
     const settings = JSON.parse(localStorageValue);
     ghTokenInput?.setAttribute("value", settings["gh-token"] || "");
+    if (includeOrgsInput) {
+      includeOrgsInput.checked = settings["include-orgs"] || false;
+    }
 
     const saveButton = document.querySelector(".js-save");
     saveButton.addEventListener("click", (_) => {
@@ -16,6 +20,7 @@
         ...settings,
         repos,
         "gh-token": apiKey,
+        "include-orgs": includeOrgsInput?.checked || false,
       };
       localStorage.setItem(localStorageKey, JSON.stringify(newSettings));
       document.querySelector(".js-save-message")?.classList.remove("js-hidden");

--- a/src/components/prs.ts
+++ b/src/components/prs.ts
@@ -54,12 +54,15 @@ export const PullRequestHtml = async (props: {
   const client = new GitHub({ token });
 
   let allPrs: Record<string, Array<PR>> = {};
+  const permissionErrorRepos: string[] = [];
 
   for (const repo of repos) {
     const [owner, repoName] = repo.split("/");
-    const prs = (await client.fetchAllPullRequests({ owner, repoName })) || [];
+    const { pullRequests, hasPermissionError } =
+      await client.fetchAllPullRequests({ owner, repoName });
     const key = `${owner}/${repoName}`;
-    const converted = prs.map((pr) => {
+    if (hasPermissionError) permissionErrorRepos.push(key);
+    const converted = pullRequests.map((pr) => {
       return {
         owner,
         repo: repoName,
@@ -86,11 +89,26 @@ export const PullRequestHtml = async (props: {
     }
   }
 
+  const callout =
+    permissionErrorRepos.length > 0
+      ? html`<div class="c-callout c-callout--warning">
+          <p>
+            CI status could not be loaded for the following repositories due to
+            insufficient token permissions. Please add
+            <strong>Commit statuses: Read</strong> to your token.
+          </p>
+          <ul>
+            ${permissionErrorRepos.map((r) => html`<li>${r}</li>`)}
+          </ul>
+        </div>`
+      : "";
+
   if (allContent.length === 0) {
-    return html`<div>No pull requests</div>`;
+    return html`<div>${callout}<div>No pull requests</div></div>`;
   }
-  return `
+  return html`<div>
+    ${callout}
     <h2>Pull Requests</h2>
-    ${allContent.join("")}
-    `;
+    ${allContent}
+  </div>`;
 };

--- a/src/components/prs.ts
+++ b/src/components/prs.ts
@@ -104,7 +104,10 @@ export const PullRequestHtml = async (props: {
       : "";
 
   if (allContent.length === 0) {
-    return html`<div>${callout}<div>No pull requests</div></div>`;
+    return html`<div>
+      ${callout}
+      <div>No pull requests</div>
+    </div>`;
   }
   return html`<div>
     ${callout}

--- a/src/components/repos.ts
+++ b/src/components/repos.ts
@@ -50,11 +50,14 @@ const content = (props: { repository: Array<Owner> }) => html`
 const findOwner = (owner: string, tree: Array<Owner>) =>
   tree.find((item) => item.name === owner);
 
-export const repositoryHtml = async (props: { token: string }) => {
-  const token = props.token;
+export const repositoryHtml = async (props: {
+  token: string;
+  includeOrgs?: boolean;
+}) => {
+  const { token, includeOrgs = false } = props;
 
   const client = new GitHub({ token });
-  const results = await client.fetchAllRepos();
+  const results = await client.fetchAllRepos({ includeOrgs });
 
   const tree = results
     .filter((repo) => !repo.archived)

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -47,9 +47,11 @@ app.get("/repos", (c) => {
 
 app.post("/repos", async (c) => {
   const token = c.req.raw.headers.get("everything-prs-token");
+  const includeOrgs =
+    c.req.raw.headers.get("everything-prs-include-orgs") === "1";
   let htmlContent;
   if (token) {
-    htmlContent = repositoryHtml({ token });
+    htmlContent = repositoryHtml({ token, includeOrgs });
   } else {
     htmlContent = `<div>Unauthorized</div>`;
   }

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -57,6 +57,7 @@ export type ContributionsCollection = {
 interface GraphQLResponse<T> {
   data: T;
   errors?: Array<{
+    type?: string;
     message: string;
     locations?: Array<{
       line: number;
@@ -78,7 +79,7 @@ export class GitHub {
   private async sendQuery<T>(
     query: string,
     variables?: Record<string, unknown>,
-  ): Promise<T> {
+  ): Promise<{ data: T; hasForbiddenErrors: boolean }> {
     const response = await fetch(this.endpoint, {
       method: "POST",
       headers: {
@@ -96,9 +97,13 @@ export class GitHub {
 
     const json: GraphQLResponse<T> = await response.json();
     if (json.errors && json.errors.length > 0) {
-      throw new Error(`GraphQL errors: ${JSON.stringify(json.errors)}`);
+      const fatalErrors = json.errors.filter((e) => e.type !== "FORBIDDEN");
+      if (fatalErrors.length > 0 || !json.data) {
+        throw new Error(`GraphQL errors: ${JSON.stringify(fatalErrors)}`);
+      }
+      return { data: json.data, hasForbiddenErrors: true };
     }
-    return json.data;
+    return { data: json.data, hasForbiddenErrors: false };
   }
 
   async getMe(): Promise<UserData> {
@@ -113,13 +118,14 @@ export class GitHub {
       }
     `;
 
-    const data = await this.sendQuery<{ viewer: UserData }>(query);
+    const { data } = await this.sendQuery<{ viewer: UserData }>(query);
     return data.viewer;
   }
 
   async fetchRepos(
     cursor: string | null = null,
     perPage = 100,
+    includeOrgs = false,
   ): Promise<{
     repositories: Repository[];
     hasNextPage: boolean;
@@ -138,6 +144,7 @@ export class GitHub {
                 owner {
                   login
                   avatarUrl
+                  __typename
                 }
                 name
                 isArchived
@@ -152,12 +159,12 @@ export class GitHub {
         cursor,
       };
 
-      const data = await this.sendQuery<{
+      const { data } = await this.sendQuery<{
         viewer: {
           watching: {
             pageInfo: { hasNextPage: boolean; endCursor: string | null };
             nodes: Array<{
-              owner: { login: string; avatarUrl: string };
+              owner: { login: string; avatarUrl: string; __typename: string };
               name: string;
               isArchived: boolean;
             }>;
@@ -165,12 +172,14 @@ export class GitHub {
         };
       }>(query, variables);
 
-      const repositories = data.viewer.watching.nodes.map((repo) => ({
-        owner: repo.owner.login,
-        name: repo.name,
-        archived: repo.isArchived,
-        owner_avatar_url: repo.owner.avatarUrl,
-      }));
+      const repositories = data.viewer.watching.nodes
+        .filter((repo) => includeOrgs || repo.owner.__typename === "User")
+        .map((repo) => ({
+          owner: repo.owner.login,
+          name: repo.name,
+          archived: repo.isArchived,
+          owner_avatar_url: repo.owner.avatarUrl,
+        }));
 
       return {
         repositories,
@@ -187,13 +196,15 @@ export class GitHub {
     }
   }
 
-  async fetchAllRepos(): Promise<Repository[]> {
+  async fetchAllRepos({
+    includeOrgs = false,
+  }: { includeOrgs?: boolean } = {}): Promise<Repository[]> {
     let allRepositories: Repository[] = [];
     let hasNextPage = true;
     let endCursor: string | null = null;
 
     while (hasNextPage) {
-      const result = await this.fetchRepos(endCursor);
+      const result = await this.fetchRepos(endCursor, 100, includeOrgs);
       allRepositories = [...allRepositories, ...result.repositories];
       hasNextPage = result.hasNextPage;
       endCursor = result.endCursor;
@@ -222,6 +233,7 @@ export class GitHub {
     pullRequests: PullRequest[];
     hasNextPage: boolean;
     endCursor: string | null;
+    hasPermissionError: boolean;
   }> {
     try {
       const query = `
@@ -267,7 +279,7 @@ export class GitHub {
         state: [state],
       };
 
-      const data = await this.sendQuery<{
+      const { data, hasForbiddenErrors } = await this.sendQuery<{
         repository: {
           pullRequests: {
             pageInfo: { hasNextPage: boolean; endCursor: string | null };
@@ -301,8 +313,8 @@ export class GitHub {
         data.repository.pullRequests.nodes.map((pr) => {
           const { commits, ...rest } = pr;
           let checkStatus: CheckStatusState | null = null;
-          const latestCommit = commits.nodes?.[0].commit;
-          if (latestCommit.statusCheckRollup) {
+          const latestCommit = commits.nodes?.[0]?.commit;
+          if (latestCommit?.statusCheckRollup) {
             checkStatus = latestCommit.statusCheckRollup.state;
           }
           return {
@@ -315,6 +327,7 @@ export class GitHub {
         pullRequests,
         hasNextPage: data.repository.pullRequests.pageInfo.hasNextPage,
         endCursor: data.repository.pullRequests.pageInfo.endCursor,
+        hasPermissionError: hasForbiddenErrors,
       };
     } catch (error) {
       console.error(
@@ -325,6 +338,7 @@ export class GitHub {
         pullRequests: [],
         hasNextPage: false,
         endCursor: null,
+        hasPermissionError: false,
       };
     }
   }
@@ -337,10 +351,11 @@ export class GitHub {
     owner: string;
     repoName: string;
     state?: "OPEN" | "CLOSED" | "MERGED";
-  }): Promise<PullRequest[]> {
+  }): Promise<{ pullRequests: PullRequest[]; hasPermissionError: boolean }> {
     let allPullRequests: PullRequest[] = [];
     let hasNextPage = true;
     let endCursor: string | null = null;
+    let hasPermissionError = false;
 
     while (hasNextPage) {
       const result = await this.fetchPullRequests({
@@ -353,13 +368,14 @@ export class GitHub {
       allPullRequests = [...allPullRequests, ...result.pullRequests];
       hasNextPage = result.hasNextPage;
       endCursor = result.endCursor;
+      if (result.hasPermissionError) hasPermissionError = true;
 
       if (!endCursor) {
         break;
       }
     }
 
-    return allPullRequests;
+    return { pullRequests: allPullRequests, hasPermissionError };
   }
 
   async fetchContributes(params: {
@@ -392,7 +408,7 @@ export class GitHub {
         to: `${today}T23:59:59`,
       };
 
-      const data = await this.sendQuery<{
+      const { data } = await this.sendQuery<{
         user: {
           contributionsCollection: {
             contributionCalendar: {

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -17,6 +17,15 @@ export const Settings: FC = async () => {
           />
         </div>
         <div>
+          <input
+            id="include-orgs"
+            name="include-orgs"
+            type="checkbox"
+            class="js-include-orgs"
+          />
+          <label for="include-orgs">Include organization repositories</label>
+        </div>
+        <div>
           <button class="js-save" type="submit">
             Save
           </button>


### PR DESCRIPTION
## Summary

- Migrate from classic token to fine-grained token with minimum required permissions
- Filter out organization repositories from `viewer.watching` results by checking `owner.__typename === "User"` (default behavior)
- Add "Include organization repositories" checkbox to the Settings page to opt-in to showing org repos
- Handle `FORBIDDEN` GraphQL errors gracefully — instead of throwing, show a callout on the home page listing affected repositories when CI status cannot be loaded
- Document required token permissions in README

## Required token permissions

| Permission | Access |
|-----------|--------|
| Metadata | Read (auto-granted) |
| Contents | Read |
| Pull requests | Read |
| Commit statuses | Read |

🤖 Generated with [Claude Code](https://claude.com/claude-code)