### PR TITLE
feat: Encrypt GitHub tokens before storing them in localStorage

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,27 @@
 
 ## Prepare
 
-Rename `wrangler.toml.example` to `wrangler.toml`.
+Rename `wrangler.toml.sample` to `wrangler.toml`.
+
+### Token encryption key
+
+GitHub tokens submitted from the Settings page are encrypted server-side before being stored in the browser. Generate a base64-encoded 32-byte key:
+
+```shell
+openssl rand -base64 32
+```
+
+For local development, add it to `.dev.vars`:
+
+```
+TOKEN_ENCRYPTION_KEY=<generated key>
+```
+
+For production, register it as a Cloudflare Workers secret:
+
+```shell
+wrangler secret put TOKEN_ENCRYPTION_KEY
+```
 
 ## GitHub Token
 

--- a/public/static/css/style.css
+++ b/public/static/css/style.css
@@ -176,6 +176,12 @@ legend {
   display: block;
 }
 
+.c-preference-hint {
+  display: block;
+  margin-top: -0.25rem;
+  font-size: 0.875rem;
+}
+
 .c-repos-list {
   padding: 0;
   margin-top: 0;

--- a/public/static/js/settings.js
+++ b/public/static/js/settings.js
@@ -1,29 +1,74 @@
 {
   window.addEventListener("DOMContentLoaded", (_) => {
     const ghTokenInput = document.querySelector(".js-gh-token");
+    const ghTokenHint = document.querySelector(".js-gh-token-hint");
     const includeOrgsInput = document.querySelector(".js-include-orgs");
 
     const localStorageKey = "everything-prs";
     const localStorageValue = localStorage.getItem(localStorageKey) || "{}";
     const settings = JSON.parse(localStorageValue);
-    ghTokenInput?.setAttribute("value", settings["gh-token"] || "");
+    const hasExistingToken = Boolean(settings["gh-token"]);
+    if (ghTokenInput) {
+      ghTokenInput.setAttribute(
+        "placeholder",
+        hasExistingToken ? "******" : "",
+      );
+    }
+    if (ghTokenHint) {
+      ghTokenHint.classList.toggle("js-hidden", !hasExistingToken);
+    }
     if (includeOrgsInput) {
       includeOrgsInput.checked = settings["include-orgs"] || false;
     }
 
+    async function encryptToken(token) {
+      const response = await fetch("/api/token/encrypt", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token }),
+      });
+      if (!response.ok) {
+        return null;
+      }
+      const { encrypted } = await response.json();
+      return encrypted;
+    }
+
+    function saveSettings(newSettings) {
+      localStorage.setItem(localStorageKey, JSON.stringify(newSettings));
+    }
+
+    function showSaveResult(ok) {
+      document
+        .querySelector(".js-save-error")
+        ?.classList.toggle("js-hidden", ok);
+      document
+        .querySelector(".js-save-message")
+        ?.classList.toggle("js-hidden", !ok);
+    }
+
     const saveButton = document.querySelector(".js-save");
-    saveButton.addEventListener("click", (_) => {
-      const apiKey = ghTokenInput?.value || "";
+    saveButton.addEventListener("click", async (_) => {
+      const inputValue = ghTokenInput?.value || "";
       const repos = settings["repos"] || [];
 
-      const newSettings = {
+      let ghToken = settings["gh-token"] || "";
+      if (inputValue) {
+        const encrypted = await encryptToken(inputValue);
+        if (encrypted === null) {
+          showSaveResult(false);
+          return;
+        }
+        ghToken = encrypted;
+      }
+
+      saveSettings({
         ...settings,
         repos,
-        "gh-token": apiKey,
+        "gh-token": ghToken,
         "include-orgs": includeOrgsInput?.checked || false,
-      };
-      localStorage.setItem(localStorageKey, JSON.stringify(newSettings));
-      document.querySelector(".js-save-message")?.classList.remove("js-hidden");
+      });
+      showSaveResult(true);
     });
   });
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import app from "./index";
+
+const testEnv = {
+  TZ: "Asia/Tokyo",
+  TOKEN_ENCRYPTION_KEY: "MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDE=",
+};
+
+describe("POST /api/token/encrypt", () => {
+  it.each([
+    ["missing", {}],
+    ["not a string", { token: 123 }],
+  ])("returns 400 when token is %s", async (_label, body) => {
+    const res = await app.request(
+      "/api/token/encrypt",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Origin: "http://localhost",
+        },
+        body: JSON.stringify(body),
+      },
+      testEnv,
+    );
+
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when the request body is not valid JSON", async () => {
+    const res = await app.request(
+      "/api/token/encrypt",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Origin: "http://localhost",
+        },
+        body: "{not valid json",
+      },
+      testEnv,
+    );
+
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 403 when the Origin header is missing", async () => {
+    const res = await app.request(
+      "/api/token/encrypt",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token: "ghp_example" }),
+      },
+      testEnv,
+    );
+
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 403 when the Origin header does not match the request origin", async () => {
+    const res = await app.request(
+      "/api/token/encrypt",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Origin: "https://evil.example.com",
+        },
+        body: JSON.stringify({ token: "ghp_example" }),
+      },
+      testEnv,
+    );
+
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 200 when the Origin header matches the request origin", async () => {
+    const res = await app.request(
+      "/api/token/encrypt",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Origin: "http://localhost",
+        },
+        body: JSON.stringify({ token: "ghp_example" }),
+      },
+      testEnv,
+    );
+
+    expect(res.status).toBe(200);
+  });
+});

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,4 @@
-import { Hono } from "hono";
+import { Context, Hono } from "hono";
 import { serveStatic } from "hono/cloudflare-workers";
 import manifest from "__STATIC_CONTENT_MANIFEST";
 
@@ -7,10 +7,26 @@ import { PullRequestHtml } from "./components/prs";
 import { repositoryHtml } from "./components/repos";
 import { TodayContributionHtml } from "./components/contribution";
 import { html } from "hono/html";
+import { importEncryptionKey, encryptToken, resolveToken } from "./lib/token";
 
 type Bindings = {
   TZ: string;
+  TOKEN_ENCRYPTION_KEY: string;
 };
+
+type AppContext = Context<{ Bindings: Bindings }>;
+
+const UNAUTHORIZED_HTML = `<div>Unauthorized</div>`;
+
+function getTokenKey(c: AppContext, usage: KeyUsage): Promise<CryptoKey> {
+  return importEncryptionKey(c.env.TOKEN_ENCRYPTION_KEY, [usage]);
+}
+
+async function resolveTokenFromRequest(c: AppContext): Promise<string | null> {
+  const encryptedToken = c.req.raw.headers.get("everything-prs-token");
+  const key = await getTokenKey(c, "decrypt");
+  return resolveToken(key, encryptedToken);
+}
 
 const app = new Hono<{ Bindings: Bindings }>();
 
@@ -20,21 +36,37 @@ app.get("/", (c) => {
   return c.html(<Home />);
 });
 
-app.post("/prs", async (c) => {
-  const token = c.req.raw.headers.get("everything-prs-token");
-  const body = await c.req.json();
-  let htmlContent;
-  if (token) {
-    const pullRequestHtml = await PullRequestHtml({ token, repos: body.repos });
-    const contributionHtml = await TodayContributionHtml({
-      token,
-      tz: c.env.TZ,
-    });
-    htmlContent = contributionHtml + pullRequestHtml;
-  } else {
-    htmlContent = `<div>Unauthorized</div>`;
+app.post("/api/token/encrypt", async (c) => {
+  const origin = c.req.header("origin");
+  if (!origin || origin !== new URL(c.req.url).origin) {
+    return c.json({ error: "origin not allowed" }, 403);
   }
-  return c.html(htmlContent);
+  let body;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: "invalid json" }, 400);
+  }
+  if (typeof body.token !== "string") {
+    return c.json({ error: "token must be a string" }, 400);
+  }
+  const key = await getTokenKey(c, "encrypt");
+  const encrypted = await encryptToken(key, body.token);
+  return c.json({ encrypted });
+});
+
+app.post("/prs", async (c) => {
+  const token = await resolveTokenFromRequest(c);
+  if (!token) {
+    return c.html(UNAUTHORIZED_HTML);
+  }
+  const body = await c.req.json();
+  const pullRequestHtml = await PullRequestHtml({ token, repos: body.repos });
+  const contributionHtml = await TodayContributionHtml({
+    token,
+    tz: c.env.TZ,
+  });
+  return c.html(contributionHtml + pullRequestHtml);
 });
 
 app.get("/settings", (c) => {
@@ -46,17 +78,13 @@ app.get("/repos", (c) => {
 });
 
 app.post("/repos", async (c) => {
-  const token = c.req.raw.headers.get("everything-prs-token");
+  const token = await resolveTokenFromRequest(c);
+  if (!token) {
+    return c.html(UNAUTHORIZED_HTML);
+  }
   const includeOrgs =
     c.req.raw.headers.get("everything-prs-include-orgs") === "1";
-  let htmlContent;
-  if (token) {
-    htmlContent = repositoryHtml({ token, includeOrgs });
-  } else {
-    htmlContent = `<div>Unauthorized</div>`;
-  }
-
-  return c.html(htmlContent);
+  return c.html(repositoryHtml({ token, includeOrgs }));
 });
 
 export default app;

--- a/src/lib/token.test.ts
+++ b/src/lib/token.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  importEncryptionKey,
+  encryptToken,
+  decryptToken,
+  resolveToken,
+} from "./token";
+
+const testBase64Key = "MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDE=";
+
+describe("encryptToken / decryptToken", () => {
+  it("round-trips a token back to its original value", async () => {
+    const key = await importEncryptionKey(testBase64Key);
+    const token = "ghp_exampletoken1234567890";
+
+    const encrypted = await encryptToken(key, token);
+    const decrypted = await decryptToken(key, encrypted);
+
+    expect(decrypted).toBe(token);
+  });
+
+  it("produces ciphertext in the v1:<iv>:<ciphertext> format", async () => {
+    const key = await importEncryptionKey(testBase64Key);
+    const encrypted = await encryptToken(key, "ghp_exampletoken1234567890");
+
+    expect(encrypted).toMatch(/^v1:[A-Za-z0-9+/]+=*:[A-Za-z0-9+/]+=*$/);
+  });
+
+  it("produces a different ciphertext each time for the same token", async () => {
+    const key = await importEncryptionKey(testBase64Key);
+    const token = "ghp_exampletoken1234567890";
+
+    const first = await encryptToken(key, token);
+    const second = await encryptToken(key, token);
+
+    expect(first).not.toBe(second);
+  });
+
+  it("throws when the encrypted string has an invalid format", async () => {
+    const key = await importEncryptionKey(testBase64Key);
+
+    await expect(decryptToken(key, "not-a-valid-format")).rejects.toThrow();
+  });
+
+  it("throws when decrypting with a different key (tamper/auth-tag check)", async () => {
+    const key = await importEncryptionKey(testBase64Key);
+    const otherKey = await importEncryptionKey(
+      "ZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXp7fH1+f4CBgoM=",
+    );
+    const encrypted = await encryptToken(key, "ghp_exampletoken1234567890");
+
+    await expect(decryptToken(otherKey, encrypted)).rejects.toThrow();
+  });
+
+  it("round-trips an empty string token", async () => {
+    const key = await importEncryptionKey(testBase64Key);
+
+    const encrypted = await encryptToken(key, "");
+    const decrypted = await decryptToken(key, encrypted);
+
+    expect(decrypted).toBe("");
+  });
+});
+
+describe("resolveToken", () => {
+  it("returns the decrypted token for a valid encrypted token", async () => {
+    const key = await importEncryptionKey(testBase64Key);
+    const encrypted = await encryptToken(key, "ghp_exampletoken1234567890");
+
+    const result = await resolveToken(key, encrypted);
+
+    expect(result).toBe("ghp_exampletoken1234567890");
+  });
+
+  it("returns null when the encrypted token is null", async () => {
+    const key = await importEncryptionKey(testBase64Key);
+
+    const result = await resolveToken(key, null);
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when decryption fails", async () => {
+    const key = await importEncryptionKey(testBase64Key);
+
+    const result = await resolveToken(key, "not-a-valid-format");
+
+    expect(result).toBeNull();
+  });
+
+  it("logs a reason when decryption fails, without leaking the encrypted or decrypted token", async () => {
+    const key = await importEncryptionKey(testBase64Key);
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const badEncrypted = "v1:not-a-valid-iv:not-a-valid-ciphertext";
+
+    await resolveToken(key, badEncrypted);
+
+    expect(errorSpy).toHaveBeenCalled();
+    const loggedText = errorSpy.mock.calls.flat().join(" ");
+    expect(loggedText).not.toContain(badEncrypted);
+
+    errorSpy.mockRestore();
+  });
+});

--- a/src/lib/token.ts
+++ b/src/lib/token.ts
@@ -1,0 +1,82 @@
+const IV_LENGTH_BYTES = 12;
+const FORMAT_PREFIX = "v1";
+
+function base64ToBytes(base64: string): Uint8Array {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary);
+}
+
+export async function importEncryptionKey(
+  base64Key: string,
+  usages: KeyUsage[] = ["encrypt", "decrypt"],
+): Promise<CryptoKey> {
+  return crypto.subtle.importKey(
+    "raw",
+    base64ToBytes(base64Key),
+    "AES-GCM",
+    false,
+    usages,
+  );
+}
+
+export async function encryptToken(
+  key: CryptoKey,
+  token: string,
+): Promise<string> {
+  const iv = crypto.getRandomValues(new Uint8Array(IV_LENGTH_BYTES));
+  const ciphertext = await crypto.subtle.encrypt(
+    { name: "AES-GCM", iv },
+    key,
+    new TextEncoder().encode(token),
+  );
+  return `${FORMAT_PREFIX}:${bytesToBase64(iv)}:${bytesToBase64(new Uint8Array(ciphertext))}`;
+}
+
+export async function decryptToken(
+  key: CryptoKey,
+  encrypted: string,
+): Promise<string> {
+  const parts = encrypted.split(":");
+  if (parts.length !== 3 || parts[0] !== FORMAT_PREFIX) {
+    throw new Error("Invalid encrypted token format");
+  }
+  const [, ivPart, ciphertextPart] = parts;
+  const iv = base64ToBytes(ivPart);
+  const ciphertext = base64ToBytes(ciphertextPart);
+  const plaintext = await crypto.subtle.decrypt(
+    { name: "AES-GCM", iv },
+    key,
+    ciphertext,
+  );
+  return new TextDecoder().decode(plaintext);
+}
+
+export async function resolveToken(
+  key: CryptoKey,
+  encryptedToken: string | null,
+): Promise<string | null> {
+  if (!encryptedToken) {
+    return null;
+  }
+  try {
+    return await decryptToken(key, encryptedToken);
+  } catch (error) {
+    console.error(
+      "Token decryption failed:",
+      error instanceof Error ? error.message : "unknown error",
+    );
+    return null;
+  }
+}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -9,6 +9,9 @@ export const Settings: FC = async () => {
           <label id="token" class="c-preference-label">
             GitHub API Token
           </label>
+          <span class="c-preference-hint js-hidden js-gh-token-hint">
+            Enter a value only if you want to change it
+          </span>
           <input
             id="gh-token"
             name="gh-token"
@@ -30,6 +33,9 @@ export const Settings: FC = async () => {
             Save
           </button>
           <span class="js-hidden js-save-message">Saved!</span>
+          <span class="js-hidden js-save-error">
+            Failed to save. Please try again.
+          </span>
         </div>
       </div>
       <script src="/static/js/settings.js" defer></script>

--- a/src/test/static-content-manifest-stub.ts
+++ b/src/test/static-content-manifest-stub.ts
@@ -1,0 +1,1 @@
+export default "{}";

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,17 @@
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      // __STATIC_CONTENT_MANIFEST is a Cloudflare Workers build-time virtual
+      // module; it doesn't exist under plain node, so route-level tests need
+      // a stub in its place.
+      __STATIC_CONTENT_MANIFEST: new URL(
+        "./src/test/static-content-manifest-stub.ts",
+        import.meta.url,
+      ).pathname,
+    },
+  },
   test: {
     environment: "node",
     include: ["src/**/*.test.ts"],

--- a/wrangler.toml.sample
+++ b/wrangler.toml.sample
@@ -7,3 +7,8 @@ bucket = "./public"
 
 [vars]
 TZ = "Asia/Tokyo"
+
+# TOKEN_ENCRYPTION_KEY is a Cloudflare Workers Secret, not a var — do not commit its value.
+# Generate a base64-encoded 32-byte key with: openssl rand -base64 32
+# Register it with: wrangler secret put TOKEN_ENCRYPTION_KEY
+# For local dev, set TOKEN_ENCRYPTION_KEY=<base64 key> in .dev.vars instead.


### PR DESCRIPTION
## Summary
- Add AES-GCM based encryption/decryption helpers for GitHub tokens (`src/lib/token.ts`)
- Add a `/api/token/encrypt` endpoint and decrypt tokens server-side when handling `/prs` and `/repos`
- Encrypt the GitHub token client-side before saving it to `localStorage`, and mask the input when a token is already stored
- Document the new `TOKEN_ENCRYPTION_KEY` secret setup in the README and `wrangler.toml.sample`

## Test plan
- [x] `pnpm test` (unit tests for `src/lib/token.ts` and `src/index.ts` routes)
- [ ] Manually verify saving/loading a token in the Settings page in a browser