### PR TITLE
feat: Add option to exclude draft pull requests

### DIFF
--- a/public/static/js/home.js
+++ b/public/static/js/home.js
@@ -10,6 +10,7 @@
       return;
     }
     const repos = settings["repos"] || {};
+    const includeDraftPrs = settings["include-draft-prs"] || false;
 
     const result = await fetch("/prs", {
       method: "POST",
@@ -18,6 +19,7 @@
       },
       body: JSON.stringify({
         repos,
+        includeDraftPrs,
       }),
     });
     const prs = await result.text();

--- a/public/static/js/settings.js
+++ b/public/static/js/settings.js
@@ -2,7 +2,9 @@
   window.addEventListener("DOMContentLoaded", (_) => {
     const ghTokenInput = document.querySelector(".js-gh-token");
     const ghTokenHint = document.querySelector(".js-gh-token-hint");
-    const includeOrgsInput = document.querySelector(".js-include-orgs");
+    const checkboxSettings = ["include-orgs", "include-draft-prs"].map(
+      (key) => ({ key, input: document.querySelector(`.js-${key}`) }),
+    );
 
     const localStorageKey = "everything-prs";
     const localStorageValue = localStorage.getItem(localStorageKey) || "{}";
@@ -17,9 +19,11 @@
     if (ghTokenHint) {
       ghTokenHint.classList.toggle("js-hidden", !hasExistingToken);
     }
-    if (includeOrgsInput) {
-      includeOrgsInput.checked = settings["include-orgs"] || false;
-    }
+    checkboxSettings.forEach(({ key, input }) => {
+      if (input) {
+        input.checked = settings[key] || false;
+      }
+    });
 
     async function encryptToken(token) {
       const response = await fetch("/api/token/encrypt", {
@@ -62,11 +66,16 @@
         ghToken = encrypted;
       }
 
+      const checkboxValues = checkboxSettings.reduce((acc, { key, input }) => {
+        acc[key] = input?.checked || false;
+        return acc;
+      }, {});
+
       saveSettings({
         ...settings,
         repos,
         "gh-token": ghToken,
-        "include-orgs": includeOrgsInput?.checked || false,
+        ...checkboxValues,
       });
       showSaveResult(true);
     });

--- a/src/components/prs.test.ts
+++ b/src/components/prs.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import type { PullRequest } from "../lib/github";
+import { filterDraftPullRequests } from "./prs";
+
+const buildPullRequest = (overrides: Partial<PullRequest>): PullRequest => ({
+  id: "1",
+  number: 1,
+  title: "some title",
+  url: "https://github.com/example/repo/pull/1",
+  state: "OPEN",
+  createdAt: "2024-01-01T00:00:00Z",
+  updatedAt: "2024-01-01T00:00:00Z",
+  author: { login: "octocat", avatarUrl: "https://example.com/avatar.png" },
+  checkStatus: null,
+  isDraft: false,
+  ...overrides,
+});
+
+describe("filterDraftPullRequests", () => {
+  it("excludes draft pull requests when includeDraftPrs is false", () => {
+    const draft = buildPullRequest({ id: "draft", isDraft: true });
+    const ready = buildPullRequest({ id: "ready", isDraft: false });
+
+    const result = filterDraftPullRequests([draft, ready], false);
+
+    expect(result).toEqual([ready]);
+  });
+
+  it("includes draft pull requests when includeDraftPrs is true", () => {
+    const draft = buildPullRequest({ id: "draft", isDraft: true });
+    const ready = buildPullRequest({ id: "ready", isDraft: false });
+
+    const result = filterDraftPullRequests([draft, ready], true);
+
+    expect(result).toEqual([draft, ready]);
+  });
+
+  it("excludes draft pull requests when includeDraftPrs is omitted", () => {
+    const draft = buildPullRequest({ id: "draft", isDraft: true });
+    const ready = buildPullRequest({ id: "ready", isDraft: false });
+
+    const result = filterDraftPullRequests([draft, ready]);
+
+    expect(result).toEqual([ready]);
+  });
+});

--- a/src/components/prs.ts
+++ b/src/components/prs.ts
@@ -1,7 +1,17 @@
 import { html } from "hono/html";
 
 import type { HtmlEscapedString } from "hono/utils/html";
-import { CheckStatusState, GitHub, state } from "../lib/github";
+import {
+  CheckStatusState,
+  GitHub,
+  state,
+  type PullRequest,
+} from "../lib/github";
+
+export const filterDraftPullRequests = (
+  pullRequests: PullRequest[],
+  includeDraftPrs = false,
+): PullRequest[] => pullRequests.filter((pr) => includeDraftPrs || !pr.isDraft);
 
 type PR = {
   owner: string;
@@ -35,10 +45,13 @@ const list = (props: { name: string; prs: Array<PR> }) => html`
   </section>
 `;
 
-export const PullRequestHtml = async (props: {
+export type PullRequestHtmlProps = {
   token: string;
   repos: Record<string, string>;
-}) => {
+  includeDraftPrs?: boolean;
+};
+
+export const PullRequestHtml = async (props: PullRequestHtmlProps) => {
   const token = props.token;
 
   if (Object.keys(props.repos).length === 0) {
@@ -62,7 +75,10 @@ export const PullRequestHtml = async (props: {
       await client.fetchAllPullRequests({ owner, repoName });
     const key = `${owner}/${repoName}`;
     if (hasPermissionError) permissionErrorRepos.push(key);
-    const converted = pullRequests.map((pr) => {
+    const converted = filterDraftPullRequests(
+      pullRequests,
+      props.includeDraftPrs,
+    ).map((pr) => {
       return {
         owner,
         repo: repoName,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -61,7 +61,11 @@ app.post("/prs", async (c) => {
     return c.html(UNAUTHORIZED_HTML);
   }
   const body = await c.req.json();
-  const pullRequestHtml = await PullRequestHtml({ token, repos: body.repos });
+  const pullRequestHtml = await PullRequestHtml({
+    token,
+    repos: body.repos,
+    includeDraftPrs: body.includeDraftPrs,
+  });
   const contributionHtml = await TodayContributionHtml({
     token,
     tz: c.env.TZ,

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -36,6 +36,7 @@ export type PullRequest = {
     avatarUrl: string;
   };
   checkStatus: CheckStatusState | null;
+  isDraft: boolean;
 };
 
 export type ContributionsCollection = {
@@ -248,6 +249,7 @@ export class GitHub {
                 state
                 createdAt
                 updatedAt
+                isDraft
                 author {
                   login
                   avatarUrl
@@ -287,6 +289,7 @@ export class GitHub {
               state: string;
               createdAt: string;
               updatedAt: string;
+              isDraft: boolean;
               author: {
                 login: string;
                 avatarUrl: string;

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,6 +1,11 @@
 import type { FC } from "hono/jsx";
 import { Layout } from "../components/Layout";
 
+const preferenceCheckboxes = [
+  { id: "include-orgs", label: "Include organization repositories" },
+  { id: "include-draft-prs", label: "Include draft pull requests" },
+];
+
 export const Settings: FC = async () => {
   return (
     <Layout title="Preference">
@@ -19,15 +24,12 @@ export const Settings: FC = async () => {
             class="js-gh-token no-margin-top"
           />
         </div>
-        <div>
-          <input
-            id="include-orgs"
-            name="include-orgs"
-            type="checkbox"
-            class="js-include-orgs"
-          />
-          <label for="include-orgs">Include organization repositories</label>
-        </div>
+        {preferenceCheckboxes.map(({ id, label }) => (
+          <div>
+            <input id={id} name={id} type="checkbox" class={`js-${id}`} />
+            <label for={id}>{label}</label>
+          </div>
+        ))}
         <div>
           <button class="js-save" type="submit">
             Save


### PR DESCRIPTION
## Summary
- Draft pull requests are now filtered out of the PR list by default (`filterDraftPullRequests` in `src/components/prs.ts`), backed by a new `isDraft` field fetched from the GitHub GraphQL API.
- Adds a "Include draft pull requests" checkbox to the Settings page, following the existing `include-orgs` pattern, and wires the saved preference through to the `/prs` request.

## Test plan
- [x] `src/components/prs.test.ts` covers `filterDraftPullRequests` (default, `true`, and `false`)
- [ ] Manually verify the Settings checkbox persists and toggles draft PRs on the home page

🤖 Generated with [Claude Code](https://claude.com/claude-code)