### PR TITLE
fix(repos): fix silent data loss when listing watched repositories

### DIFF
--- a/src/components/repos.ts
+++ b/src/components/repos.ts
@@ -57,9 +57,9 @@ export const repositoryHtml = async (props: {
   const { token, includeOrgs = false } = props;
 
   const client = new GitHub({ token });
-  const results = await client.fetchAllRepos({ includeOrgs });
+  const { repositories } = await client.fetchAllRepos({ includeOrgs });
 
-  const tree = results
+  const tree = repositories
     .filter((repo) => !repo.archived)
     .reduce((acc: Array<Owner>, repo) => {
       const owner = findOwner(repo.owner, acc);

--- a/src/components/repos.ts
+++ b/src/components/repos.ts
@@ -21,8 +21,22 @@ const repoItem = (props: { repo: string }) => {
   </li>`;
 };
 
-const content = (props: { repository: Array<Owner> }) => html`
+const content = (props: {
+  repository: Array<Owner>;
+  hasPermissionError: boolean;
+}) => html`
   <div>
+    ${
+      props.hasPermissionError
+        ? html`<div class="c-callout c-callout--warning">
+            <p>
+              Some watched repositories could not be loaded due to insufficient
+              token permissions. Please check your token's
+              <strong>Contents: Read</strong> access.
+            </p>
+          </div>`
+        : ""
+    }
     ${props.repository.map((owner) => {
       return html`<section>
         <fieldset>
@@ -57,7 +71,9 @@ export const repositoryHtml = async (props: {
   const { token, includeOrgs = false } = props;
 
   const client = new GitHub({ token });
-  const { repositories } = await client.fetchAllRepos({ includeOrgs });
+  const { repositories, hasPermissionError } = await client.fetchAllRepos({
+    includeOrgs,
+  });
 
   const tree = repositories
     .filter((repo) => !repo.archived)
@@ -83,5 +99,5 @@ export const repositoryHtml = async (props: {
       return owner;
     });
 
-  return content({ repository: repos });
+  return content({ repository: repos, hasPermissionError });
 };

--- a/src/lib/github.test.ts
+++ b/src/lib/github.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
-import { state, type CheckStatusState } from "./github";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { GitHub, state, type CheckStatusState } from "./github";
 
 describe("state", () => {
   it("has an emoji for every CheckStatusState", () => {
@@ -15,5 +15,50 @@ describe("state", () => {
       expect(state[status]).toBeTypeOf("string");
       expect(state[status].length).toBeGreaterThan(0);
     }
+  });
+});
+
+describe("GitHub#fetchRepos", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("skips nodes with a null owner instead of dropping the whole page", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: {
+          viewer: {
+            watching: {
+              pageInfo: { hasNextPage: false, endCursor: null },
+              nodes: [
+                { owner: null, name: "inaccessible-repo", isArchived: false },
+                {
+                  owner: {
+                    login: "octocat",
+                    avatarUrl: "https://example.com/a.png",
+                    __typename: "User",
+                  },
+                  name: "hello-world",
+                  isArchived: false,
+                },
+              ],
+            },
+          },
+        },
+      }),
+    } as Response);
+
+    const client = new GitHub({ token: "test-token" });
+    const result = await client.fetchRepos();
+
+    expect(result.repositories).toEqual([
+      {
+        owner: "octocat",
+        name: "hello-world",
+        archived: false,
+        owner_avatar_url: "https://example.com/a.png",
+      },
+    ]);
   });
 });

--- a/src/lib/github.test.ts
+++ b/src/lib/github.test.ts
@@ -62,6 +62,28 @@ describe("GitHub#fetchRepos", () => {
     ]);
   });
 
+  it("reports hasPermissionError when the API returns FORBIDDEN errors", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: {
+          viewer: {
+            watching: {
+              pageInfo: { hasNextPage: false, endCursor: null },
+              nodes: [],
+            },
+          },
+        },
+        errors: [{ type: "FORBIDDEN", message: "Resource not accessible" }],
+      }),
+    } as Response);
+
+    const client = new GitHub({ token: "test-token" });
+    const result = await client.fetchRepos();
+
+    expect(result.hasPermissionError).toBe(true);
+  });
+
   it("reports hasError instead of silently ending pagination on failure", async () => {
     vi.spyOn(global, "fetch").mockRejectedValue(new Error("network down"));
     vi.spyOn(console, "error").mockImplementation(() => {});
@@ -111,5 +133,27 @@ describe("GitHub#fetchAllRepos", () => {
 
     expect(result.repositories).toHaveLength(1);
     expect(result.hasError).toBe(true);
+  });
+
+  it("propagates hasPermissionError from any page", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: {
+          viewer: {
+            watching: {
+              pageInfo: { hasNextPage: false, endCursor: null },
+              nodes: [],
+            },
+          },
+        },
+        errors: [{ type: "FORBIDDEN", message: "Resource not accessible" }],
+      }),
+    } as Response);
+
+    const client = new GitHub({ token: "test-token" });
+    const result = await client.fetchAllRepos();
+
+    expect(result.hasPermissionError).toBe(true);
   });
 });

--- a/src/lib/github.test.ts
+++ b/src/lib/github.test.ts
@@ -61,4 +61,55 @@ describe("GitHub#fetchRepos", () => {
       },
     ]);
   });
+
+  it("reports hasError instead of silently ending pagination on failure", async () => {
+    vi.spyOn(global, "fetch").mockRejectedValue(new Error("network down"));
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const client = new GitHub({ token: "test-token" });
+    const result = await client.fetchRepos();
+
+    expect(result.hasError).toBe(true);
+  });
+});
+
+describe("GitHub#fetchAllRepos", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("propagates hasError when a page fails mid-pagination", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const fetchMock = vi.spyOn(global, "fetch");
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        data: {
+          viewer: {
+            watching: {
+              pageInfo: { hasNextPage: true, endCursor: "cursor-1" },
+              nodes: [
+                {
+                  owner: {
+                    login: "octocat",
+                    avatarUrl: "https://example.com/a.png",
+                    __typename: "User",
+                  },
+                  name: "hello-world",
+                  isArchived: false,
+                },
+              ],
+            },
+          },
+        },
+      }),
+    } as Response);
+    fetchMock.mockRejectedValueOnce(new Error("network down"));
+
+    const client = new GitHub({ token: "test-token" });
+    const result = await client.fetchAllRepos();
+
+    expect(result.repositories).toHaveLength(1);
+    expect(result.hasError).toBe(true);
+  });
 });

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -132,7 +132,7 @@ export class GitHub {
       const query = `
         query getWatchedRepos($perPage: Int!, $cursor: String) {
           viewer {
-            watching(first: $perPage, after: $cursor) {
+            watching(first: $perPage, after: $cursor, orderBy: {field: NAME, direction: ASC}) {
               pageInfo {
                 hasNextPage
                 endCursor

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -127,6 +127,7 @@ export class GitHub {
     repositories: Repository[];
     hasNextPage: boolean;
     endCursor: string | null;
+    hasError: boolean;
   }> {
     try {
       const query = `
@@ -187,6 +188,7 @@ export class GitHub {
         repositories,
         hasNextPage: data.viewer.watching.pageInfo.hasNextPage,
         endCursor: data.viewer.watching.pageInfo.endCursor,
+        hasError: false,
       };
     } catch (error) {
       console.error("Error fetching watched repositories:", error);
@@ -194,29 +196,35 @@ export class GitHub {
         repositories: [],
         hasNextPage: false,
         endCursor: null,
+        hasError: true,
       };
     }
   }
 
   async fetchAllRepos({
     includeOrgs = false,
-  }: { includeOrgs?: boolean } = {}): Promise<Repository[]> {
+  }: { includeOrgs?: boolean } = {}): Promise<{
+    repositories: Repository[];
+    hasError: boolean;
+  }> {
     let allRepositories: Repository[] = [];
     let hasNextPage = true;
     let endCursor: string | null = null;
+    let hasError = false;
 
     while (hasNextPage) {
       const result = await this.fetchRepos(endCursor, 100, includeOrgs);
       allRepositories = [...allRepositories, ...result.repositories];
       hasNextPage = result.hasNextPage;
       endCursor = result.endCursor;
+      if (result.hasError) hasError = true;
 
       if (!endCursor) {
         break;
       }
     }
 
-    return allRepositories;
+    return { repositories: allRepositories, hasError };
   }
 
   async fetchPullRequests({

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -128,6 +128,7 @@ export class GitHub {
     hasNextPage: boolean;
     endCursor: string | null;
     hasError: boolean;
+    hasPermissionError: boolean;
   }> {
     try {
       const query = `
@@ -157,7 +158,7 @@ export class GitHub {
         cursor,
       };
 
-      const { data } = await this.sendQuery<{
+      const { data, hasForbiddenErrors } = await this.sendQuery<{
         viewer: {
           watching: {
             pageInfo: { hasNextPage: boolean; endCursor: string | null };
@@ -189,6 +190,7 @@ export class GitHub {
         hasNextPage: data.viewer.watching.pageInfo.hasNextPage,
         endCursor: data.viewer.watching.pageInfo.endCursor,
         hasError: false,
+        hasPermissionError: hasForbiddenErrors,
       };
     } catch (error) {
       console.error("Error fetching watched repositories:", error);
@@ -197,6 +199,7 @@ export class GitHub {
         hasNextPage: false,
         endCursor: null,
         hasError: true,
+        hasPermissionError: false,
       };
     }
   }
@@ -206,11 +209,13 @@ export class GitHub {
   }: { includeOrgs?: boolean } = {}): Promise<{
     repositories: Repository[];
     hasError: boolean;
+    hasPermissionError: boolean;
   }> {
     let allRepositories: Repository[] = [];
     let hasNextPage = true;
     let endCursor: string | null = null;
     let hasError = false;
+    let hasPermissionError = false;
 
     while (hasNextPage) {
       const result = await this.fetchRepos(endCursor, 100, includeOrgs);
@@ -218,13 +223,14 @@ export class GitHub {
       hasNextPage = result.hasNextPage;
       endCursor = result.endCursor;
       if (result.hasError) hasError = true;
+      if (result.hasPermissionError) hasPermissionError = true;
 
       if (!endCursor) {
         break;
       }
     }
 
-    return { repositories: allRepositories, hasError };
+    return { repositories: allRepositories, hasError, hasPermissionError };
   }
 
   async fetchPullRequests({

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -161,7 +161,11 @@ export class GitHub {
           watching: {
             pageInfo: { hasNextPage: boolean; endCursor: string | null };
             nodes: Array<{
-              owner: { login: string; avatarUrl: string; __typename: string };
+              owner: {
+                login: string;
+                avatarUrl: string;
+                __typename: string;
+              } | null;
               name: string;
               isArchived: boolean;
             }>;
@@ -170,6 +174,7 @@ export class GitHub {
       }>(query, variables);
 
       const repositories = data.viewer.watching.nodes
+        .filter((repo) => repo.owner !== null)
         .filter((repo) => includeOrgs || repo.owner.__typename === "User")
         .map((repo) => ({
           owner: repo.owner.login,


### PR DESCRIPTION
## Summary
- Add `orderBy: {field: NAME, direction: ASC}` to the `viewer.watching` GraphQL query so pagination order is stable across pages.
- Guard against watched-repo nodes with a `null` owner (e.g. repos the token can no longer fully resolve) instead of throwing, which previously caused the whole page to be silently dropped.
- Propagate `hasError` from `fetchRepos` through `fetchAllRepos` so a failed page no longer silently truncates the rest of the pagination with `hasNextPage: false` and no signal.
- Propagate GraphQL `FORBIDDEN` errors (`hasForbiddenErrors`) as `hasPermissionError` up to the Repositories page and show a warning callout, mirroring the existing pattern on the Pull Requests page.

## Context
Investigated a report that recently added repositories don't show up on the Repositories screen. Root cause for the reported case was outside the app (fine-grained token scope / watch status), but the investigation surfaced several real bugs in `src/lib/github.ts` around silent truncation and swallowed errors that made it impossible for the app to explain *why* a repo was missing. This PR fixes those.

## Test plan
- [x] `pnpm vitest run` passes (25 tests)
- [x] `pnpm run lint` passes
- [x] Manually verify the permission-error callout renders on `/repos` with a token missing repo access